### PR TITLE
Secrets capability

### DIFF
--- a/charts/hobbyfarm/templates/admin-ui/ingress.yaml
+++ b/charts/hobbyfarm/templates/admin-ui/ingress.yaml
@@ -20,5 +20,8 @@ spec:
   tls:
   - hosts:
     - {{ $.Values.ingress.hostnames.admin }}
+{{- if hasKey .Values.ingress.tls.secrets "admin" }}
+    secretName: {{ $.Values.ingress.tls.secrets.admin }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/charts/hobbyfarm/templates/gargantua/ingress.yaml
+++ b/charts/hobbyfarm/templates/gargantua/ingress.yaml
@@ -20,5 +20,8 @@ spec:
   tls:
   - hosts:
     - {{ $.Values.ingress.hostnames.backend }}
+{{- if hasKey .Values.ingress.tls.secrets "backend" }}
+    secretName: {{ $.Values.ingress.tls.secrets.backend }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/charts/hobbyfarm/templates/gargantua/shell.yaml
+++ b/charts/hobbyfarm/templates/gargantua/shell.yaml
@@ -62,5 +62,8 @@ spec:
   tls:
   - hosts:
     - {{ $.Values.ingress.hostnames.shell }}
+{{- if hasKey .Values.ingress.tls.secrets "shell" }}
+    secretName: {{ $.Values.ingress.tls.secrets.shell }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/charts/hobbyfarm/templates/ui/ingress.yaml
+++ b/charts/hobbyfarm/templates/ui/ingress.yaml
@@ -20,5 +20,8 @@ spec:
   tls:
   - hosts:
     - {{ $.Values.ingress.hostnames.ui }}
+{{- if hasKey .Values.ingress.tls.secrets "ui" }}
+    secretName: {{ $.Values.ingress.tls.secrets.ui }}
+{{- end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This is needed to allow cert-manager to issue certificates for the ingress hostnames that are specified.