### PR TITLE
ui-v-0-4-4

### DIFF
--- a/charts/hobbyfarm/Chart.yaml
+++ b/charts/hobbyfarm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hobbyfarm
-version: 0.2.1
+version: 0.2.2
 description: interactive coding platform in a browser
 
 sources:

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -1,7 +1,7 @@
 admin:
   image: hobbyfarm/admin-ui:v0.2.0
 ui:
-  image: hobbyfarm/ui:v0.4.3
+  image: hobbyfarm/ui:v0.4.4
   # configMapName: ui-config
 gargantua:
   image: hobbyfarm/gargantua:v0.1.7


### PR DESCRIPTION
Bumps ui to v0.4.4

This is so scenarios can have a "Close" button which preserves the session while allowing the user to continue to another scenario in a course. 