### PR TITLE
Fixed various chart issues

### DIFF
--- a/charts/hobbyfarm/Chart.yaml
+++ b/charts/hobbyfarm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hobbyfarm
-version: 0.2.3
+version: 0.2.4
 description: interactive coding platform in a browser
 
 sources:

--- a/charts/hobbyfarm/templates/seed/environment.yaml
+++ b/charts/hobbyfarm/templates/seed/environment.yaml
@@ -12,8 +12,7 @@ spec:
       image: {{ (index .Values.terraform .Values.terraform.provider).image }}
 
   environment_specifics:
-    module: tf-module
-    executor_image: {{ .Values.terraform.executor_image }}
+    executor_image: {{ .Values.terraform.executor.image }}:{{ .Values.terraform.executor.tag }}
 
     {{ if eq .Values.terraform.provider "ranchervm" }}
 {{ toYaml .Values.terraform.ranchervm | indent 4 -}}

--- a/charts/hobbyfarm/templates/terraform/module.yaml
+++ b/charts/hobbyfarm/templates/terraform/module.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   git:
-    url: {{ (index $.Values.terraform $.Values.terraform.provider).module }}
+    url: {{ (index $.Values.terraform $.Values.terraform.provider).module_repo }}
 {{ end }}

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -48,18 +48,21 @@ terraform:
   provider: aws
 
   ranchervm:
-    module: https://github.com/hobbyfarm/tf-module-rvm
+    module: tf-module
+    module_repo: https://github.com/hobbyfarm/tf-module-rvm
     image: rancher/vm-ubuntu:16.04.5-server-amd64
     endpoint: "http://backend.ranchervm-system:9500"
     access_key: ''
     secret_key: ''
 
   google:
-    module: https://github.com/boxboat/tf-module-google
+    module: tf-module
+    module_repo: https://github.com/boxboat/tf-module-google
     # credentials: |
 
   aws:
-    module: https://github.com/hobbyfarm/tf-module-aws
+    module: tf-module
+    module_repo: https://github.com/hobbyfarm/tf-module-aws
     image: ami-04763b3055de4860b
     region: us-east-1
     # access_key:
@@ -68,10 +71,12 @@ terraform:
     # vpc_security_group_id:
 
   vsphere:
-    module: https://github.com/hobbyfarm/tf-module-vsphere
+    module: tf-module
+    module_repo: https://github.com/hobbyfarm/tf-module-vsphere
 
   do:
-    module: https://github.com/dramich/domodule
+    module: tf-module
+    module_repo: https://github.com/dramich/domodule
 
 # https://github.com/hobbyfarm/vm
 ranchervm:


### PR DESCRIPTION
The chart was not easily installable for two reasons:

1. When creating the terraform module, the name of the module object was not correctly getting set in the `environment_specifics` of the environment. Instead, we were using the git repo. 
2. The executor image was not rendering into the `environment_specifics` because of a mismatched helm key. 