### PR TITLE
Bump UI to v0.4.5

### DIFF
--- a/charts/hobbyfarm/Chart.yaml
+++ b/charts/hobbyfarm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hobbyfarm
-version: 0.2.5
+version: 0.2.6
 description: interactive coding platform in a browser
 
 sources:

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -1,7 +1,7 @@
 admin:
   image: hobbyfarm/admin-ui:v0.2.1
 ui:
-  image: hobbyfarm/ui:v0.4.4
+  image: hobbyfarm/ui:v0.4.5
   # configMapName: ui-config
 gargantua:
   image: hobbyfarm/gargantua:v0.1.8


### PR DESCRIPTION
Bumps UI to v0.4.5 to address hobbyfarm/hobbyfarm#116
