### PR TITLE
Whitelabel admin UI

### DIFF
--- a/charts/hobbyfarm/templates/admin-ui/configmap.yaml
+++ b/charts/hobbyfarm/templates/admin-ui/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: hobbyfarm
+  name: admin-config
+data:
+  {{ if $.Values.admin.config -}}
+  config.json: |
+    {
+        "title": {{ $.Values.admin.config.title | quote }},
+        "favicon": {{ $.Values.admin.config.favicon | quote }},
+        "login": {
+            "logo": {{ $.Values.admin.config.login.logo | quote }},
+            "background": {{ $.Values.admin.config.login.background | quote }}
+        },
+        "logo": {{ $.Values.admin.config.logo | quote }}
+    }
+  {{- end }}

--- a/charts/hobbyfarm/templates/admin-ui/deployment.yaml
+++ b/charts/hobbyfarm/templates/admin-ui/deployment.yaml
@@ -26,3 +26,15 @@ spec:
               {{ else }}
               value: gargantua
               {{ end }}
+      {{- if $.Values.admin.configMapName }}
+          volumeMounts:
+            {{ if $.Values.admin.config }}
+            - name: config
+              mountPath: /usr/share/nginx/html/config.json
+              subPath: config.json
+            {{ end }}
+      volumes:
+        - name: config
+          configMap: 
+            name: {{ $.Values.admin.configMapName }}
+      {{- end }}

--- a/charts/hobbyfarm/templates/admin-ui/deployment.yaml
+++ b/charts/hobbyfarm/templates/admin-ui/deployment.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         component: admin-ui
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/admin-ui/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: admin-ui

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -1,5 +1,13 @@
 admin:
   image: hobbyfarm/admin-ui:v0.2.5
+  # configMapName: admin-config
+  # config:
+    # title: HobbyFarm Administration
+    # favicon: /assets/default/favicon.png
+    # login:
+      # logo: /assets/default/rancher-labs-stacked-color.svg
+      # background: assets/default/vault.jpg
+    # logo: /assets/default/logo.svg
 ui:
   image: hobbyfarm/ui:v0.4.8
   # configMapName: ui-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables white labeling for the admin ui (similar to hobbyfarm ui). Values for the config.json file can be set in values.yaml. 
Example:
```
...
admin:
  image: hobbyfarm/admin-ui:v0.2.5
  configMapName: admin-config
  config:
    title: HobbyFarm Administration
    favicon: /assets/default/favicon.png
    login:
      logo: /assets/default/rancher-labs-stacked-color.svg
      background: assets/default/vault.jpg
    logo: /assets/default/logo.svg
...
```
