### PR TITLE
Change to checkout v2 with fetch-depth

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # actions/checkout@v1 must be included to checkout the repo
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with: 
+        fetch-depth: 2
 
     - name: check if version was bumped
       run: git diff HEAD~1 charts/hobbyfarm/Chart.yaml | grep 'version:'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the checkout action to v2. Using fetch-depth we ensure that the last 2 commits are checked out so we can calculate if the version was bumped - just like before.

**Which issue(s) this PR fixes**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/172
