### PR TITLE
Allow whitelabeling for the about section

### DIFF
--- a/charts/hobbyfarm/templates/ui/configmap.yaml
+++ b/charts/hobbyfarm/templates/ui/configmap.yaml
@@ -13,7 +13,21 @@ data:
             "logo": {{ $.Values.ui.config.login.logo | quote }},
             "background": {{ $.Values.ui.config.login.background | quote }}
         },
-        "logo": {{ $.Values.ui.config.logo | quote }}
+        "logo": {{ $.Values.ui.config.logo | quote }},
+        "about": {
+            {{ if $.Values.ui.config.about -}}
+            "title": {{ $.Values.ui.config.about.title | default "" | quote }},
+            "body": {{ $.Values.ui.config.about.body | default "" | quote }},
+            "buttons": [
+            {{- range $index, $val := $.Values.ui.config.about.buttons }}
+            {
+                {{ "title" | quote | indent 4}}: {{ $val.title | quote }},
+                {{ "url" | quote | indent 4}}: {{ $val.url | quote }}
+            }{{ if ne (add1 $index) (len $.Values.ui.config.about.buttons) }},{{ end }}
+            {{- end }}
+            ]
+            {{- end }}
+        }
     }
   {{- end }}
   {{ if $.Values.ui.custom -}}

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -18,6 +18,14 @@ ui:
       # logo: /assets/default/rancher-labs-stacked-color.svg
       # background: /assets/default/login_container_farm.svg
     # logo: /assets/default/logo.svg
+    # about: 
+      # title: About HobbyFarm
+      # body: HobbyFarm was lovingly crafted by @ebauman and @Oats87 from @RancherLabs
+      # buttons:
+        # - title: Example Title
+        #   url: https://github.com/hobbyfarm
+        # - title: Example Title 2
+        #   url: https://github.com/hobbyfarm/hobbyfarm
   # custom: |
     # .custom-css {
       # /* Some custom css */


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows to customize the about page via Helm. After customization, the About Modal may look like this:
![image](https://user-images.githubusercontent.com/38468835/157276349-9ceda7bf-596a-47b0-b2e9-0480005fb189.png)

As shown, there is also an option to add buttons linking to external web pages.
Works along with https://github.com/hobbyfarm/ui/pull/132.

**Which issue(s) this PR fixes**:
Fixes #190
