### PR TITLE
Guac config

### DIFF
--- a/charts/hobbyfarm/templates/guacamole/deployment.yaml
+++ b/charts/hobbyfarm/templates/guacamole/deployment.yaml
@@ -1,0 +1,19 @@
+{{ if $.Values.guac }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guacd
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      component: guacd
+  template:
+    metadata:
+      labels:
+        component: guacd
+    spec:
+      containers:
+        - name: guacd
+          image: guacamole/guacd
+{{ end }}

--- a/charts/hobbyfarm/templates/guacamole/guac.yaml
+++ b/charts/hobbyfarm/templates/guacamole/guac.yaml
@@ -1,0 +1,19 @@
+{{ if $.Values.guac }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guac
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      component: guac
+  template:
+    metadata:
+      labels:
+        component: guac
+    spec:
+      containers:
+        - name: guac
+          image: {{ $.Values.guac.image }}
+{{ end }}

--- a/charts/hobbyfarm/templates/guacamole/service.guac.yaml
+++ b/charts/hobbyfarm/templates/guacamole/service.guac.yaml
@@ -1,0 +1,14 @@
+{{ if $.Values.guac }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: guac
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    component: guac
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4567
+{{ end }}

--- a/charts/hobbyfarm/templates/guacamole/service.yaml
+++ b/charts/hobbyfarm/templates/guacamole/service.yaml
@@ -1,0 +1,16 @@
+{{ if $.Values.guac }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: guacd
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    component: guacd
+  type: ClusterIP
+  ports:
+    - name: tcp
+      port: 4822
+      targetPort: 4822
+      protocol: TCP
+{{ end }}

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -28,6 +28,10 @@ gargantua:
   dynamicBaseNamePrefix: "dynamic"
   scheduledBaseNamePrefix: "scheduled"
 
+# Use guacamole to provision windows VMs (optional)
+# guac:
+#   image: ***to be published***
+
 shell:
   replicas: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the option to provision windows VMs via guacamole
