### PR TITLE
upgrade k3s image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
 
   k3d:
-    image: rancher/k3s:v1.17.2-k3s1
+    image: rancher/k3s:v1.21.13-k3s1
     container_name: hf-k3d
     hostname: k3d
     privileged: true


### PR DESCRIPTION
makes container start on newer Ubuntu machines that only have cgroup v2

**What this PR does / why we need it**:
makes k3s start on Ubuntu 20.04 and above

**Which issue(s) this PR fixes**:
Fixes #202 
