### PR TITLE
Fix Schema, RBAC APIGroup in example role

### DIFF
--- a/charts/hobbyfarm/crds/crds.yaml
+++ b/charts/hobbyfarm/crds/crds.yaml
@@ -33,7 +33,7 @@ spec:
               id:
                 nullable: true
                 type: string
-              keypair_name:
+              secret_name:
                 nullable: true
                 type: string
               provision:

--- a/docs/upgrade/2.0.0/README.md
+++ b/docs/upgrade/2.0.0/README.md
@@ -30,3 +30,6 @@ Execute [rbac_converter.sh](rbac_converter.sh) to automatically apply RBAC chang
 3. For each one of these users, create a rolebinding that maps them to the `hobbyfarm-admin` user. 
 
         kubectl create rolebinding --namespace [hobbyfarm-install-namespace] --role=hobbyfarm-admin --user=[user]
+
+### Let Gargantua create default Roles
+Gargantua can also create default roles like "scheduled event creator" or "readonly users". To enable gargantua to create those roles the `installrbacroles` flag must be provided during the start of gargantua.

--- a/docs/upgrade/2.0.0/role.yaml
+++ b/docs/upgrade/2.0.0/role.yaml
@@ -6,6 +6,6 @@ rules:
 - apiGroups: ["hobbyfarm.io"]
   resources: ["*"]
   verbs: ["*"]
-- apiGroups: ["authorization.rbac.k8s.io"]
+- apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
   verbs: ["*"]


### PR DESCRIPTION
**What this PR does / why we need it**:
During the guacamole implmentation we renamed the keypair_name field to secret_name. 
In the Upgrade manual to the 2.0 the API Group was wrong.