### PR TITLE
Fix typo (rename property count_map of VirtualMachineTemplate crd to config_map)

### DIFF
--- a/charts/hobbyfarm/crds/crds.yaml
+++ b/charts/hobbyfarm/crds/crds.yaml
@@ -186,7 +186,7 @@ spec:
         properties:
           spec:
             properties:
-              count_map:
+              config_map:
                 additionalProperties:
                   nullable: true
                   type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a little typo. Property count_map was named config_map before and is causing issues in our admin ui. 
