### PR TITLE
added initial admin user and role

### DIFF
--- a/charts/hobbyfarm/templates/rbac/admin-role.yaml
+++ b/charts/hobbyfarm/templates/rbac/admin-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: hobbyfarm-admin
+    namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["hobbyfarm.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["*"]

--- a/charts/hobbyfarm/templates/rbac/admin-rolebinding.yaml
+++ b/charts/hobbyfarm/templates/rbac/admin-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: hobbyfarm-admin-rolebinding
+    namespace: {{ .Release.Namespace }}
+subjects:
+- kind: User
+  name: hobbyfarm-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: hobbyfarm-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/hobbyfarm/templates/rbac/user.yaml
+++ b/charts/hobbyfarm/templates/rbac/user.yaml
@@ -1,0 +1,9 @@
+apiVersion: hobbyfarm.io/v2
+kind: User
+metadata:
+    name: hobbyfarm-admin
+    namespace: {{ .Release.Namespace }}
+spec:
+    id: hobbyfarm-admin
+    email: admin
+    password: $2a$10$wlCtD3St//eVdaYLU1Z.tOb0wGQ55Zs1BFpcgHZ3AbLw9LloWqWWy # hobbyfarm


### PR DESCRIPTION
Currently there is no default admin user when installing HobbyFarm via Helm chart. 

This means that a user needs to create a user manifest with a bcrypt password in it. That's a crappy UX.

This PR introduces a change to add a default admin user with username `admin` and password `hobbyfarm`.
It also includes a default admin role and rolebinding for that user. 
