### PR TITLE
Add missing serviceAccountName

### DIFF
--- a/charts/hobbyfarm/templates/gargantua/shell.yaml
+++ b/charts/hobbyfarm/templates/gargantua/shell.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: gargantua-shell
     spec:
+      serviceAccountName: {{ .Values.gargantua.serviceAccountName }}
       containers:
       - name: gargantua
         image: {{ $.Values.gargantua.image }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the gargantuan serviceaccount name to the deployment spec

**Which issue(s) this PR fixes**:

closes #262 
