### PR TITLE
Add missing shell key under tls secrets

### DIFF
--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -60,6 +60,7 @@ ingress:
     #   backend: backend-tls-secret # api/controller server
     #   admin: admin-tls-secret # admin ui
     #   ui: ui-tls-secret # user frontend "learn" ui
+    #   shell: shell-tls-secret # shell proxy
   hostnames:
     # ui: example.com
     # admin: admin.example.com


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the missing shell key for the tls secret
