### PR TITLE
Remove about modal buttons from values.yml

### DIFF
--- a/charts/hobbyfarm/templates/ui/configmap.yaml
+++ b/charts/hobbyfarm/templates/ui/configmap.yaml
@@ -16,14 +16,6 @@ data:
         "about": {
             "title": {{ $.Values.ui.config.about.title | default "" | quote }},
             "body": {{ $.Values.ui.config.about.body | default "" | quote }},
-            "buttons": [
-            {{- range $index, $val := $.Values.ui.config.about.buttons }}
-            {
-                {{ "title" | quote | indent 4}}: {{ $val.title | quote }},
-                {{ "url" | quote | indent 4}}: {{ $val.url | quote }}
-            }{{ if ne (add1 $index) (len $.Values.ui.config.about.buttons) }},{{ end }}
-            {{- end }}
-            ]
         }
     }
   {{- if $.Values.ui.custom }}

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -28,11 +28,6 @@ ui:  # defaults for UI service
     about:
       title: About HobbyFarm
       body: HobbyFarm is a browser-based technology training tool developed at github.com/hobbyfarm
-      # buttons:
-        # - title: Example Title
-        #   url: https://github.com/hobbyfarm
-        # - title: Example Title 2
-        #   url: https://github.com/hobbyfarm/hobbyfarm
   # custom: |
     # .custom-css {
       # /* Some custom css */


### PR DESCRIPTION
**What this PR does / why we need it**:
about modal Buttons were removed from the values.yml and moved to settings in https://github.com/hobbyfarm/gargantua/pull/168

**Which issue(s) this PR fixes**:

<!-- 
Automatically close issues.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
