### PR TITLE
Fix wrong namespace for initial admin account

### DIFF
--- a/charts/hobbyfarm/templates/user-service/user.yaml
+++ b/charts/hobbyfarm/templates/user-service/user.yaml
@@ -4,8 +4,8 @@ apiVersion: hobbyfarm.io/v2
 kind: User
 metadata:
   name: admin
+  namespace: {{ .Release.Namespace }}
 spec:
-  id: admin
   email: admin
   password: {{ $.Values.users.admin.password }}
   access_codes: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes https://github.com/hobbyfarm/hobbyfarm/issues/443 by removing the spec.id which is not needed and setting the namespace to the correct namespace