### PR TITLE
Add service for cost-tracking

### DIFF
--- a/charts/hobbyfarm/templates/cost-service/configmap.yaml
+++ b/charts/hobbyfarm/templates/cost-service/configmap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cost-config
+data:
+  config.json: |
+    {{- if $.Values.cost.trackableResources }}
+    {{ toJson $.Values.cost.trackableResources | indent 4 }}
+    {{- else }}
+    []
+    {{- end }}

--- a/charts/hobbyfarm/templates/cost-service/deployment.yaml
+++ b/charts/hobbyfarm/templates/cost-service/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cost-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ $.Values.cost.replicas }}
+  selector:
+    matchLabels:
+      component: cost-service
+  template:
+    metadata:
+      labels:
+        component: cost-service
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/tls-certificates/grpc-secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.cost.serviceAccountName }}
+      containers:
+        - name: cost-service
+          image: {{ $.Values.cost.image }}
+          command: ["app"]
+          args:
+          - "-v=9"
+          - "-logtostderr"
+          - --enableReflection={{ .Values.general.enableReflection }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ $.Values.cost.logLevel | quote }}
+            - name: HF_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: PORT
+              value: {{ .Values.cost.apiPort | quote }}
+            - name: GRPC_PORT
+              value: "8080"
+            - name: STATEFULSET_NAME
+              value: "cost-service"
+            - name: CONTROLLER_THREAD_COUNT
+              value: {{ .Values.cost.controllerWorkerThreadCount | quote }}
+          ports:
+          - containerPort: {{ .Values.cost.apiPort }}
+          - containerPort: 8080
+          volumeMounts:
+          - name: cost-secret
+            mountPath: "/etc/ssl/certs/ca.crt"
+            subPath: ca.crt
+            readOnly: true
+          - name: cost-secret
+            mountPath: "/etc/ssl/certs/tls.key"
+            subPath: tls.key
+            readOnly: true
+          - name: cost-secret
+            mountPath: "/etc/ssl/certs/tls.crt"
+            subPath: tls.crt
+            readOnly: true
+          - name: webhook-secret
+            mountPath: "/webhook-secret/ca.crt"
+            subPath: ca.crt
+            readOnly: true
+          - name: config
+            mountPath: "/etc/cost-config.json"
+            subPath: config.json
+            readOnly: true
+      volumes:
+      - name: cost-secret
+        secret:
+          secretName: hobbyfarm-grpc-secret
+          optional: false
+      - name: webhook-secret
+        secret:
+          secretName: hobbyfarm-webhook-secret
+          optional: false
+      - name: config
+        configMap:
+          name: cost-config

--- a/charts/hobbyfarm/templates/cost-service/rbac.yaml
+++ b/charts/hobbyfarm/templates/cost-service/rbac.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cost-{{ .Release.Namespace }}
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cost-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.cost.serviceAccountName }}
+roleRef:
+  kind: ClusterRole
+  name: cost-{{ .Release.Namespace }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: costsvc
+rules:
+  - apiGroups: [""]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["hobbyfarm.io"]
+    resources: ["costs"]
+    verbs: ["*"]
+  {{- if .Values.cost.trackableResources }}
+  {{- range .Values.cost.trackableResources }}
+  - apiGroups: ["{{ .group }}"]
+    resources: ["{{ .resource }}"]
+    verbs: ["list", "watch"]
+  {{- end }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: costsvc
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.cost.serviceAccountName }}
+roleRef:
+  kind: Role
+  name: costsvc
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/hobbyfarm/templates/cost-service/service-grpc.yaml
+++ b/charts/hobbyfarm/templates/cost-service/service-grpc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cost-service-grpc
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterIP: None
+  selector:
+    component: cost-service
+  ports:
+  - name: grpc
+    protocol: TCP
+    port: 8080

--- a/charts/hobbyfarm/templates/cost-service/service.yaml
+++ b/charts/hobbyfarm/templates/cost-service/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cost-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    component: cost-service
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.cost.apiPort }}

--- a/charts/hobbyfarm/templates/cost-service/serviceaccount.yaml
+++ b/charts/hobbyfarm/templates/cost-service/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.cost.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/hobbyfarm/templates/gargantua/ingress.yaml
+++ b/charts/hobbyfarm/templates/gargantua/ingress.yaml
@@ -147,6 +147,14 @@ spec:
               name: environment-service
               port: 
                 number: {{ $.Values.environment.apiPort }}
+        # cost-service
+        - pathType: Prefix
+          path: "/a/cost"
+          backend:
+            service:
+              name: cost-service
+              port: 
+                number: {{ $.Values.cost.apiPort }}
         # course-service
         - pathType: Prefix
           path: "/a/course"

--- a/charts/hobbyfarm/values.yaml
+++ b/charts/hobbyfarm/values.yaml
@@ -53,6 +53,16 @@ conversion:
   containerPort: 444
   servicePort: 443  # needs to remain 443, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#deploy-the-conversion-webhook-servicev2
   serviceAccountName: "hobbyfarm-conversion"
+cost:
+  image: hobbyfarm/cost-service:master
+  replicas: 1
+  logLevel: "0"
+  apiPort: 80
+  serviceAccountName: "hobbyfarm-cost"
+  trackableResources: # add all non default kubernetes resources for cost tracking
+    - group: "hobbyfarm.io"
+      version: "v1"
+      resource: "virtualmachines"
 course:
   image: hobbyfarm/course-service:v3.2.5
   replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

The cost-service offers the posibility to track resource costs. A cost is produced by a running resource (can be kubernetes default or custom) and costs are grouped in a cost-group. The implementation of the `cost-service` can he found at https://github.com/hobbyfarm/gargantua/pull/212

The `cost-service` dynamically observes all resources with label `cost-group`. The resources to observe are defined in `values.yaml` under `cost.trackableResources`. The permissions to observe non kubernetes default  resources, are added during helm execution. As well as the creation of the `cost-config` `ConfigMap`

**Which issue(s) this PR fixes**:

Usage: Fixes https://github.com/hobbyfarm/hobbyfarm/issues/483
